### PR TITLE
Update gtk to 0.2 to avoid clash in tests

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ features = ["v2_36"]
 version = "0.4"
 
 [dev-dependencies]
-gtk = "0.1"
+gtk = "0.2"
 
 [features]
 nightly = []


### PR DESCRIPTION
This PR updates the dev-dependency gtk to 0.2.

Before, resolving the current Cargo.toml would lead to two different versions of gtk-sys would be linked, leading to a compilation failure.