### PR TITLE
Make IoChannel interface safer

### DIFF
--- a/src/io/mod.rs
+++ b/src/io/mod.rs
@@ -20,14 +20,11 @@ pub struct IoChannel {
     inner: *mut glib_sys::GIOChannel,
 }
 
-unsafe impl Send for IoChannel {} // FIXME: probably wrong
-
 impl IoChannel {
     #[cfg(unix)]
-    pub fn unix_new(fd: RawFd) -> Self {
-        let ptr = unsafe {
-            glib_sys::g_io_channel_unix_new(fd)
-        };
+    pub unsafe fn unix_new(fd: RawFd) -> Self {
+        let ptr = glib_sys::g_io_channel_unix_new(fd);
+
         assert!(!ptr.is_null());
         IoChannel {
             inner: ptr,


### PR DESCRIPTION
Remove Send marker from IoChannel. It is internally
reference-counted and implements Clone, allowing to
hand out multiple references to it. This can be used
to get concurrent access from two threads.

Make `unix_new` unsafe, following the argument of
Rusts `from_raw_fd` method: the method can be used
with an illegal RawFd, which might later lead to
memory unsafety.